### PR TITLE
Specify a compatible version of JSONStream in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "cheerio": "^0.19.0",
     "entities": "^1.1.1",
     "hexo-util": "^0.1.6"
+  },
+  "peerDependencies": {
+    "JSONStream": "1.0.6"
   }
 }


### PR DESCRIPTION
This fixes issue #3 (the "this.stack[k].value = null" error).
